### PR TITLE
Add sudo burn without approval requirement

### DIFF
--- a/contracts/l2/dai.sol
+++ b/contracts/l2/dai.sol
@@ -165,7 +165,7 @@ contract Dai {
     uint256 balance = balanceOf[from];
     require(balance >= value, "Dai/insufficient-balance");
 
-    if (from != msg.sender) {
+    if (from != msg.sender && wards[msg.sender] != 1) {
       uint256 allowed = allowance[from][msg.sender];
       if (allowed != type(uint256).max) {
         require(allowed >= value, "Dai/insufficient-allowance");

--- a/test/l2/L2DAITokenBridge.ts
+++ b/test/l2/L2DAITokenBridge.ts
@@ -260,26 +260,12 @@ describe('OVM_L2DAITokenBridge', () => {
       ).to.be.revertedWith(errorMessages.tokenMismatch)
     })
 
-    it('reverts when approval is too low', async () => {
-      const [_, l2MessengerImpersonator, user1, user2] = await ethers.getSigners()
-      const { l2Dai, l2DAITokenBridge } = await setupWithdrawTest({
-        l2MessengerImpersonator,
-        user1,
-      })
-      await l2Dai.connect(user1).transfer(user2.address, withdrawAmount)
-
-      await expect(
-        l2DAITokenBridge.connect(user2).withdraw(l2Dai.address, withdrawAmount, defaultGas, defaultData),
-      ).to.be.revertedWith(errorMessages.daiInsufficientAllowance)
-    })
-
     it('reverts when not enough funds', async () => {
       const [_, l2MessengerImpersonator, user1, user2] = await ethers.getSigners()
       const { l2Dai, l2DAITokenBridge } = await setupWithdrawTest({
         l2MessengerImpersonator,
         user1,
       })
-      await l2Dai.connect(user1).approve(l2DAITokenBridge.address, withdrawAmount)
 
       await expect(
         l2DAITokenBridge.connect(user2).withdraw(l2Dai.address, withdrawAmount, defaultGas, defaultData),
@@ -396,28 +382,12 @@ describe('OVM_L2DAITokenBridge', () => {
       ).to.be.revertedWith(errorMessages.tokenMismatch)
     })
 
-    it('reverts when approval is too low', async () => {
-      const [_, l2MessengerImpersonator, receiver, user1, user2] = await ethers.getSigners()
-      const { l2Dai, l2DAITokenBridge } = await setupWithdrawTest({
-        l2MessengerImpersonator,
-        user1,
-      })
-      await l2Dai.connect(user1).transfer(user2.address, withdrawAmount)
-
-      await expect(
-        l2DAITokenBridge
-          .connect(user2)
-          .withdrawTo(l2Dai.address, receiver.address, withdrawAmount, defaultGas, defaultData),
-      ).to.be.revertedWith(errorMessages.daiInsufficientAllowance)
-    })
-
     it('reverts when not enough funds', async () => {
       const [_, l2MessengerImpersonator, receiver, user1, user2] = await ethers.getSigners()
       const { l2Dai, l2DAITokenBridge } = await setupWithdrawTest({
         l2MessengerImpersonator,
         user1,
       })
-      await l2Dai.connect(user1).approve(l2DAITokenBridge.address, withdrawAmount)
 
       await expect(
         l2DAITokenBridge
@@ -547,7 +517,6 @@ async function setupWithdrawTest(signers: { l2MessengerImpersonator: SignerWithA
   const contracts = await setupTest(signers)
 
   await contracts.l2Dai.mint(signers.user1.address, INITIAL_TOTAL_L1_SUPPLY)
-  await contracts.l2Dai.connect(signers.user1).approve(contracts.l2DAITokenBridge.address, ethers.constants.MaxUint256)
 
   return contracts
 }

--- a/test/l2/dai.ts
+++ b/test/l2/dai.ts
@@ -124,6 +124,13 @@ describe('Dai', () => {
         )
       })
 
+      it('deployer can burn other', async () => {
+        const balanceBefore = await dai.balanceOf(signers.user1.address)
+        await dai.connect(signers.deployer).burn(signers.user1.address, 1)
+        const balanceAfter = await dai.balanceOf(signers.user1.address)
+        expect(balanceAfter).to.be.eq(balanceBefore.sub(1))
+      })
+
       it('approves to increase allowance', async () => {
         const allowanceBefore = await dai.allowance(signers.user1.address, signers.user2.address)
         await dai.connect(signers.user1).approve(signers.user2.address, 1)


### PR DESCRIPTION
Allows the bridge to burn tokens without explicit approval.